### PR TITLE
スレッドとレスを横断した検索機能の実装

### DIFF
--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -14,6 +14,33 @@ class ForumsController < ApplicationController
     @forum = Forum.find(params[:id])
   end
 
+  def search
+    if params[:keywords] == ""
+      redirect_to root_path
+    end
+    @input = params[:keywords]
+    keywords = @input.split(/[[:blank:]]+/)
+
+    if keywords.length != 0 then
+
+        keywords.each_with_index do |w,i|
+          if i == 0 then
+            @search_forums = Forum.where('title LIKE ?', "%#{w}%")        
+          else
+            @search_forums = @search_forums.where('title LIKE ?', "%#{w}%")
+          end
+        end
+
+        keywords.each_with_index do |w,i|
+          if i == 0 then
+            @search_responses = Response.where('text LIKE ?', "%#{w}%")        
+          else
+            @search_responses = @search_responses.where('text LIKE ?', "%#{w}%")
+          end
+        end
+    end
+  end
+
 
   private
   def create_forum_params

--- a/app/views/forums/index.html.haml
+++ b/app/views/forums/index.html.haml
@@ -2,7 +2,7 @@
   .row
     = render 'category-sidebar'
     .col-lg-8.main-box
-      新着
+      新着スレッド
       .list-group
         - Forum.all.order(id: "DESC").each do|forum|
           %a.list-group-item.list-group-item-action{:href => "forums/#{forum.id}"}

--- a/app/views/forums/search.html.haml
+++ b/app/views/forums/search.html.haml
@@ -1,0 +1,32 @@
+.container-fluid.w
+  .row
+    .col-lg-6.main-box
+      スレタイの検索結果
+      .list-group 
+        - if @search_forums.length == 0
+          %p 検索結果はありません！
+        - @search_forums.order(id: "DESC").each do |forum|
+          %a.list-group-item.list-group-item-action{:href => "forums/#{forum.id}"}
+            .d-flex.w-100.justify-content-between
+              %h5.mb-1
+                = forum.title
+              %small
+                = forum.created_at
+            %small
+              - forum.categories.each do |c|
+                = "##{c.category}"
+    .col-lg-6.main-box
+      レスの検索結果
+      .list-group
+        - if @search_responses.length == 0
+          %p 検索結果はありません！
+        - @search_responses.order(id: "DESC").each do |res|
+          %a.list-group-item.list-group-item-action{:href => "forums/#{res.forum.id}"}
+            .d-flex.w-100.justify-content-between
+              %h5.mb-1
+                = res.text
+              %small
+                = res.created_at
+            %small
+              - res.forum.categories.each do |c|
+                = "##{c.category}"

--- a/app/views/layouts/header/_header-navbar.html.haml
+++ b/app/views/layouts/header/_header-navbar.html.haml
@@ -1,9 +1,9 @@
 %nav.navbar
   = link_to root_path,{class:"navbar__title"} do
     %h1 4BEchan
-  %form.form-inline
-    %input.form-control.mr-sm-2{"aria-label" => "Search", :placeholder => "Search", :type => "search"}/
-    %button.btn.btn-outline-success.my-2.my-sm-0.btn-outline-light{:type => "submit"} Search
+  = form_with url: forums_search_path, local: true, class: "form-inline" do |f|
+    = f.text_field :keywords, {class: "form-control mr-sm-2",placeholder: "Search",value: @input}
+    = f.submit "Search", {class: "btn btn-outline-success my-2 my-sm-0 btn-outline-light"}
   - if user_signed_in?
     .btn-group
       %button.btn.btn-outline-light{"data-target" => "#exampleModal", "data-toggle" => "modal", "data-whatever" => "@mdo",:type => "button"} スレッド作成

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,6 @@ Rails.application.routes.draw do
   resources :forums, only: [:show,:create] do
     resources :responses, only: [:create]
   end
+  post '/forums/search', to: 'forums#search'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
実装内容
- 検索結果ページの作成
スレとレスは別々のタブで表示する。
- 検索ロジックの作成
キーワードを半角or全角区切りで入力されたものを検索できる様にした。
検索キーワードがないものについてはroot_pathへリダイレクトする様にした。