### PR TITLE
[add] 未ログインユーザーの機能制限

### DIFF
--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -1,4 +1,5 @@
 class ForumsController < ApplicationController
+  before_action :authenticate_user!,only:[:create]
   def create
     @forum = Forum.new(create_forum_params)
     @forum.responses.first.user_id = current_user.id

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -1,4 +1,5 @@
 class ResponsesController < ApplicationController
+  before_action :authenticate_user!,only:[:create]
 
   def create
     forum = Forum.find(params[:forum_id])

--- a/app/views/forums/show.html.haml
+++ b/app/views/forums/show.html.haml
@@ -18,15 +18,15 @@
                 -# 2020/01/01(月) 00:00:00
             .forum-list__response--text
               = r.text
-
-      = form_with model:[@forum,Response.new],local: true,class: "forum-form" do |f|
-        .form-group
-          %label{:for => "nickname"} nickname
-          = f.text_field :nickname, {class:"form-control", id:"nickname"}
-        .form-group
-          %label{:for => "responseText"} text
-          = f.text_field :text, {class:"form-control", id:"responseText"}
-        = f.submit "Submit", {class: "btn btn-primary"}
+      - if user_signed_in?
+        = form_with model:[@forum,Response.new],local: true,class: "forum-form" do |f|
+          .form-group
+            %label{:for => "nickname"} nickname
+            = f.text_field :nickname, {class:"form-control", id:"nickname"}
+          .form-group
+            %label{:for => "responseText"} text
+            = f.text_field :text, {class:"form-control", id:"responseText"}
+          = f.submit "Submit", {class: "btn btn-primary"}
 
 
     = render 'my-forum-sidebar'


### PR DESCRIPTION
実装内容
- 未ログインユーザーのコントローラーアクションの利用制限
利用不可にしたのは以下のコントローラ#アクション
forums#create,responses#create

- 未ログインユーザーへフォームを表示させない様にする
スレページ(/forum/:forum_id)のレスをするためのフォームをログインしていなければ非表示にした。