### PR TITLE
リンクの修正

### DIFF
--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -7,7 +7,7 @@
         - if @forums.length == 0
           %p 検索結果はありません！
         - @forums.order(id: "DESC").each do |forum|
-          %a.list-group-item.list-group-item-action{:href => "forums/#{forum.id}"}
+          %a.list-group-item.list-group-item-action{:href => "/forums/#{forum.id}"}
             .d-flex.w-100.justify-content-between
               %h5.mb-1
                 = forum.title


### PR DESCRIPTION
カテゴリ検索からフォーラムページへのリンクを踏むとエラーになっていたので修正した。